### PR TITLE
fix(Heading.js): copy childNodes and children to heading tag

### DIFF
--- a/src/es/components/atoms/heading/Heading.js
+++ b/src/es/components/atoms/heading/Heading.js
@@ -24,11 +24,6 @@ export default class Heading extends Shadow() {
         this.heading.setAttribute(attrib.name, attrib.value)
       }
     }
-
-    // copy children to heading
-    while (this.root.firstElementChild) {
-      this.heading.appendChild(this.root.firstElementChild)
-    }
   }
 
   connectedCallback () {
@@ -303,6 +298,15 @@ export default class Heading extends Shadow() {
    * @returns void
    */
   renderHTML () {
+    Array.from(this.childNodes).forEach(node => {
+      if (node.nodeName === '#text') {
+        this.heading.appendChild(node)
+      }
+    })
+    Array.from(this.root.children).forEach(node => {
+      if (node === this.heading || node.getAttribute('slot') || node.nodeName === 'STYLE') return false
+      this.heading.appendChild(node)
+    })
     this.html = this.heading
   }
 }


### PR DESCRIPTION
Fixes issue where text nodes not beeing copied to heading tag.
Adds support for both cases:
```
<ks-a-heading tag="h1">
  <a-translation key="CustomerLoyality.PageTitle"></a-translation>
</ks-a-heading>
<ks-a-heading tag="h1">
  Test Title
</ks-a-heading>
```

Problem is that the `#text` node is not an element and is not returned when using the property `.children`. It is also not beeing handled by the [Shadow class](https://github.com/mits-gossau/web-components-toolbox/blob/master/src/es/components/prototypes/Shadow.js#L99)