### PR TITLE
NOJIRA/fix-radio-button-behavior

### DIFF
--- a/src/es/components/atoms/checkbox/Checkbox.js
+++ b/src/es/components/atoms/checkbox/Checkbox.js
@@ -40,6 +40,7 @@ export default class Checkbox extends Shadow() {
         }
 
         :host .wrap {
+          position: relative;
           display: flex;
           flex-direction: column;
         }
@@ -49,34 +50,36 @@ export default class Checkbox extends Shadow() {
           opacity: 0.2;
         }
 
-        :host .control:hover,
-        :host label:hover {
+        :host .control:hover label {
           background-color: var(--background);
           cursor: pointer;
         }
 
         :host .control {
+          flex: 1;
           display: flex;
           flex-direction: row-reverse;
-          width: fit-content;
-          padding-top: var(--padding-top);
-          padding-bottom: var(--padding-bottom);
-          padding-right: var(--padding-right);
         }
 
         :host label {
+          flex: 1;
           font-size: 1em;
           line-height: 1.25em;
           font-weight: 400;
-          padding: var(--label-padding, 0);   
-          }
+          padding: 
+              var(--padding-top)
+              var(--padding-right)
+              var(--padding-bottom)
+              calc(var(--padding-right) + 1.25em)
+          ;
+        }
           
-          :host label a {
-            display: inline !important;
-            font-size: 1em;
-            line-height: 1.25em;
-            font-weight: 400;
-          }
+        :host label a {
+          display: inline !important;
+          font-size: 1em;
+          line-height: 1.25em;
+          font-weight: 400;
+        }
 
         :host input[type='checkbox'] {
             width: 0;
@@ -93,13 +96,16 @@ export default class Checkbox extends Shadow() {
         }
 
         :host .box {
-            background-color: var(--box-background-color);
-            border: 0.0625em solid var(--border-color);
-            border-radius: var(--border-radius, 0);
-            height: 1.25em;
-            width: 1.25em;
-            margin-right: 0.75em;
-            flex: 1 0 1.25em;
+          position: absolute;
+          left: 0;
+          top: var(--padding-top);
+          background-color: var(--box-background-color);
+          border: 0.0625em solid var(--border-color);
+          border-radius: var(--border-radius, 0);
+          height: 1.25em;
+          width: 1.25em;
+          margin-right: 0.75em;
+          flex: 1 0 1.25em;
         }
 
         :host .box a-icon-mdx {
@@ -143,12 +149,6 @@ export default class Checkbox extends Shadow() {
         return this.fetchCSS([
           {
             path: `${this.importMetaUrl}./default-/default-.css`, // apply namespace since it is specific and no fallback
-            namespace: false
-          }])
-      case 'center-list-':
-        return this.fetchCSS([
-          {
-            path: `${this.importMetaUrl}./center-list-/center-list-.css`,
             namespace: false
           }])
     }

--- a/src/es/components/atoms/checkbox/center-list-/center-list-.css
+++ b/src/es/components/atoms/checkbox/center-list-/center-list-.css
@@ -1,6 +1,0 @@
-:host {
-    --center-list-border-color: var(--m-grey-700);
-    --center-list-box-background-color: var(--m-white);
-    --center-list-color: var(--color-secondary);
-    --center-list-label-padding: calc(14rem/18) 0;
-}

--- a/src/es/components/atoms/checkbox/default-/default-.css
+++ b/src/es/components/atoms/checkbox/default-/default-.css
@@ -4,7 +4,8 @@
     --checkbox-default-color: #0053A6;
     --checkbox-default-padding-top: var(--mdx-comp-checkbox-padding-vertical-default);
     --checkbox-default-padding-bottom: var(--mdx-comp-checkbox-padding-vertical-default);
-    --checkbox-default-padding-right: var(--mdx-comp-checkbox-padding-horizontal-default);
+    --checkbox-default-padding-right: var(--mdx-comp-checkbox-padding-horizontal-default); 
+    --checkbox-default-padding-left: calc(var(--mdx-comp-checkbox-padding-horizontal-default) + var(--mdx-comp-checkbox-sizing-ellipse));
     --checkbox-default-background: var(--mdx-comp-checkbox-unchecked-background-color-hover);
     --button-secondary-icon-right-margin: 0;
     --checkbox-default-error-color: var(--mdx-comp-error-message-color-default);

--- a/src/es/components/atoms/radio/Radio.js
+++ b/src/es/components/atoms/radio/Radio.js
@@ -7,23 +7,13 @@ export default class Radio extends Shadow() {
 
     this.boxes = Array.from(this.root.querySelectorAll('.box') || [])
     this.inputs = Array.from(this.root.querySelectorAll('input[type="radio"]') || [])
-
-    this.clickEventListener = event => {
-      this.inputs[this.boxes.indexOf(event.target)].checked = !this.inputs[this.boxes.indexOf(event.target)].checked
-    }
   }
 
   connectedCallback () {
     if (this.shouldRenderCSS()) this.renderCSS()
-
-    /**
-     * Handle checked on box
-     */
-    this.boxes.forEach(box => box.addEventListener('click', this.clickEventListener))
   }
 
   disconnectedCallback () {
-    this.boxes.forEach(box => box.removeEventListener('click', this.clickEventListener))
   }
 
   shouldRenderCSS () {
@@ -127,6 +117,9 @@ export default class Radio extends Shadow() {
           height: var(--mdx-comp-radiobutton-sizing-ellipse);
           width: var(--mdx-comp-radiobutton-sizing-ellipse);
           min-width: var(--mdx-comp-radiobutton-sizing-ellipse);
+
+          /* by setting pointer events to none the input will be clickable as it is behind the box */
+          pointer-events: none;
         }
 
         :host(:not(:has(.has-error))) > .message {

--- a/src/es/components/atoms/radio/Radio.js
+++ b/src/es/components/atoms/radio/Radio.js
@@ -47,9 +47,6 @@ export default class Radio extends Shadow() {
           flex-direction: row-reverse;
           justify-content: flex-end;
           align-items: center;
-          padding-top: var(--mdx-comp-radiobutton-padding-vertical-default);
-          padding-bottom: var(--mdx-comp-radiobutton-padding-vertical-default);
-          padding-right: var(--mdx-comp-radiobutton-padding-horizontal-default);
         }
 
         :host .wrap.disabled {
@@ -66,17 +63,21 @@ export default class Radio extends Shadow() {
           border-color: var(--mdx-comp-radiobutton-checked-icon-border-disabled);
         }
 
-        :host .wrap:hover,
-        :host label:hover {
+        :host .wrap:hover label {
           background-color: var(--mdx-comp-radiobutton-unchecked-background-color-hover);
           cursor: pointer;
         }
 
         :host label {
+          flex: 1;
+          display: block;
           font-size: 1em;
           line-height: 1.25em;
           font-weight: 400;
           padding-left: calc(var(--mdx-comp-radiobutton-padding-horizontal-default) + var(--mdx-comp-radiobutton-sizing-ellipse));
+          padding-top: var(--mdx-comp-radiobutton-padding-vertical-default);
+          padding-bottom: var(--mdx-comp-radiobutton-padding-vertical-default);
+          padding-right: var(--mdx-comp-radiobutton-padding-horizontal-default);
           margin-left: calc(var(--mdx-comp-radiobutton-sizing-ellipse) / 2 * -1);
         }
 


### PR DESCRIPTION
I removed the event listener from the box and also added "pointer-events: none;" to the css of the box. This way the click on the input itself is dispatched correctly restoring the default browser behavior of the radio.

Please check if everything works as expected @Weedshaker @MrBuggy 