### PR TITLE
fix: add option to use html element inside ks-a-heading

### DIFF
--- a/src/es/components/atoms/heading/Heading.js
+++ b/src/es/components/atoms/heading/Heading.js
@@ -14,7 +14,9 @@ export default class Heading extends Shadow() {
     this.styleAs = this.getAttribute('style-as')
     this.color = this.getAttribute('color') || 'var(--mdx-base-color-grey-975)'
 
-    this.heading = document.createElement(this.tag)
+    const existingHeadline = this.root.querySelector('h1, h2, h3, h4, h5')
+    this.heading = existingHeadline || document.createElement(this.tag)
+
     if (this.styleAs) this.heading.setAttribute('class', this.styleAs)
     // this.heading.setAttribute('style', `color: ${this.color}`)
 

--- a/src/es/components/atoms/heading/default-/default-.html
+++ b/src/es/components/atoms/heading/default-/default-.html
@@ -1,4 +1,8 @@
 <div>
+    <ks-a-heading display-1><h1>Display H1</h1></ks-a-heading>
+    <ks-a-heading display-2><h2>Display H2</h2></ks-a-heading>
+    <ks-a-heading display-3><h3>Display H3</h3></ks-a-heading>
+
     <ks-a-heading tag="h1" display-1>Display H1</ks-a-heading>
     <ks-a-heading tag="h2" display-2>Display H2</ks-a-heading>
     <ks-a-heading tag="h3" display-3>Display H3</ks-a-heading>

--- a/src/es/components/molecules/stage/default-/default-.html
+++ b/src/es/components/molecules/stage/default-/default-.html
@@ -9,8 +9,8 @@
     <p class="topline">
         <a href="" alt=""><a-icon-mdx icon-name="ArrowLeft" size="1em" icon-size='24x24'></a-icon-mdx> <span>Back Link</span></a>
     </p>
-    <ks-a-heading tag="h1" display-2>
-        Das ist eine Stage
+    <ks-a-heading display-2>
+        <h1>Das ist eine Stage</h1>
     </ks-a-heading>
     <a-input inputid="searchField" placeholder="Label" icon-name="Search" icon-size="1.25em" search="?q=" type="search"></a-input>
 </ks-m-stage>

--- a/src/es/components/molecules/stage/title-/title-.html
+++ b/src/es/components/molecules/stage/title-/title-.html
@@ -2,8 +2,10 @@
     <p class="topline">
         <a href="" alt=""><a-icon-mdx icon-name="ArrowLeft" size="1em" icon-size='24x24'></a-icon-mdx> <span>Back Link</span></a>
     </p>
-    <ks-a-heading tag="h1" display-3 border-top centered>
-        Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+    <ks-a-heading display-3 border-top centered>
+        <h1>
+            Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+        </h1>
     </ks-a-heading>
     <a-picture
         picture-load 

--- a/src/es/components/pages/AboDetailPage.html
+++ b/src/es/components/pages/AboDetailPage.html
@@ -122,8 +122,10 @@
         <ks-o-body-section content-width-var="100%" no-margin-y>
 
             <div class="margin-y-m">
-                <ks-a-heading tag="h3">
-                    Kontakt
+                <ks-a-heading >
+                    <h3>
+                        Kontakt
+                    </h3>
                 </ks-a-heading>
         
                 <!-- CMS Contact Component -->

--- a/src/es/components/pages/Accordion.html
+++ b/src/es/components/pages/Accordion.html
@@ -5,7 +5,9 @@
                 <h4>Lorem ipsum dolor sit amet.</h4>
             </summary>
             <div>
-                <ks-a-heading tag="h2">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus quos quaerat rerum rem, harum sed enim maiores inventore nostrum placeat!</ks-a-heading>
+                <ks-a-heading>
+                    <h2>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus quos quaerat rerum rem, harum sed enim maiores inventore nostrum placeat!</h2>
+                </ks-a-heading>
                 <div>
                     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum adipisci doloribus sapiente quidem assumenda minus. Itaque rerum natus aperiam eius?</p>
                     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex, esse obcaecati! Earum cumque culpa id.</p>

--- a/src/es/components/pages/AngebotsDetailPage.html
+++ b/src/es/components/pages/AngebotsDetailPage.html
@@ -60,7 +60,9 @@
                                 --details-default-color-secondary: var(--color-hover);
                             }
                         </style>
-                        <ks-a-heading tag="h3">test title</ks-a-heading>
+                        <ks-a-heading>
+                            <h3>test title</h3>
+                        </ks-a-heading>
                         <div>
                             <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
                                 eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -113,8 +115,8 @@
         <!-- /CMS Akkordeon Container -->
     </ks-o-body-section>
     <aside>
-        <ks-a-heading tag="h3">
-            Kontakt
+        <ks-a-heading>
+            <h3>Kontakt</h3>
         </ks-a-heading>
 
         <!-- CMS Contact Component -->

--- a/src/es/components/pages/AngebotslevelPage.html
+++ b/src/es/components/pages/AngebotslevelPage.html
@@ -51,7 +51,7 @@
                                     --details-default-color-secondary: var(--color-hover);
                                 }
                             </style>
-                            <ks-a-heading tag="h3">test title</ks-a-heading>
+                            <ks-a-heading><h3>test title</h3></ks-a-heading>
                             <div>
                                 <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
                                     eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -238,7 +238,7 @@
 
 <!-- CMS Teaser Slider -->
 <ks-o-body-section variant="default">
-    <ks-a-heading tag="h2" style-as="h1">Was ist was?</ks-a-heading>
+    <ks-a-heading style-as="h1"><h2>Was ist was?</h2></ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>
             <ks-m-teaser namespace=teaser-tile-content- color="septenary" href="#">
@@ -429,7 +429,7 @@
 
 <!-- CMS Teaser Slider -->
 <ks-o-body-section variant="default">
-    <ks-a-heading tag="h2" style-as="h1" border-top>Inspiration für Sie</ks-a-heading>
+    <ks-a-heading style-as="h1" border-top><h2>Inspiration für Sie</h2></ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>
             <ks-m-teaser namespace=teaser-story- color="quinary" href="/de/entdecken/story-pink-again-nomol/">

--- a/src/es/components/pages/AngebotslevelPageWithoutSubNav.html
+++ b/src/es/components/pages/AngebotslevelPageWithoutSubNav.html
@@ -46,7 +46,7 @@
                     </summary>
                     <div>
                         
-                        <ks-a-heading tag="h3">test title</ks-a-heading>
+                        <ks-a-heading><h3>test title</h3></ks-a-heading>
                         <div>
                             <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
                                 eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -175,7 +175,7 @@
 
 <!-- CMS Teaser Slider -->
 <ks-o-body-section variant="default">
-    <ks-a-heading tag="h2" style-as="h1">Was ist was?</ks-a-heading>
+    <ks-a-heading style-as="h1"><h2>Was ist was?</h2></ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>
             <ks-m-teaser namespace=teaser-tile-content- color="septenary" href="#">
@@ -359,7 +359,7 @@
 
 <!-- CMS Teaser Slider -->
 <ks-o-body-section variant="default">
-    <ks-a-heading tag="h2" style-as="h1" border-top>Inspiration für Sie</ks-a-heading>
+    <ks-a-heading style-as="h1" border-top><h2>Inspiration für Sie</h2></ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>
             <ks-m-teaser namespace=teaser-story- color="quinary" href="/de/entdecken/story-pink-again-nomol/">

--- a/src/es/components/pages/Checkout-Abonnement-Configuration.html
+++ b/src/es/components/pages/Checkout-Abonnement-Configuration.html
@@ -17,7 +17,7 @@
                         <p>Bitte beachten Sie, dass das Abonnement nach dem Kauf zuerst durch die Klubschule manuell freigeschalten werden muss. Dieser Prozess wird nur innerhalb der normalen Arbeitszeiten durchgeführt.</p>
                     </div>
                 </ks-m-system-notification>
-                <ks-a-heading tag="h2" style-as="h1">Ab wann soll Ihr Abonnement gültig sein?</ks-a-heading>
+                <ks-a-heading style-as="h1"><h2>Ab wann soll Ihr Abonnement gültig sein?</h2></ks-a-heading>
                 <ks-a-input mode="false">
                     <div>
                         <label>Start der Gültigkeit *</label>

--- a/src/es/components/pages/ColorStage.html
+++ b/src/es/components/pages/ColorStage.html
@@ -6,7 +6,9 @@
 <h3>image inside</h3>
 <o-grid namespace="grid-2columns-content-stage-" first-container-vertical first-column-with="66%" background-color="var(--mdx-sys-color-accent-4-default)" width="100%">
     <div class="stage-content">
-        <ks-a-heading tag="h1" color="white" content-stage>Bodytoning Bauch, Beine, Po</ks-a-heading>
+        <ks-a-heading tag="h1" color="white" content-stage>
+            <h1>Bodytoning Bauch, Beine, Po h1</h1>
+        </ks-a-heading>
     </div>
     <aside>
         <img src="https://mits-gossau.github.io/web-components-toolbox-klubschule/src/img/content-stage/a59843713cfd9aefb7e8d172513e4bea.png" alt="" />

--- a/src/es/components/pages/ContentPage.html
+++ b/src/es/components/pages/ContentPage.html
@@ -8,7 +8,7 @@
     width="100%"
 >
     <div>
-        <ks-a-heading tag="h1" color="white" content-stage>ContentPage (B&uuml;hne) Lorem Ipsum dolor bis zur zweiten Zeile</ks-a-heading>
+        <ks-a-heading color="white" content-stage><h1>ContentPage (B&uuml;hne) Lorem Ipsum dolor bis zur zweiten Zeile</h1></ks-a-heading>
         <p class="intro">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
             labore. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
             dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
@@ -220,12 +220,12 @@
     <!-- /CMS Table -->
     
     <!-- Beispiele CMS Titel Komponenten -->
-    <ks-a-heading tag="h1">Titel H1</ks-a-heading>
-    <ks-a-heading tag="h2">Titel H2</ks-a-heading>
-    <ks-a-heading tag="h3">Titel H3</ks-a-heading>
-    <ks-a-heading tag="h1" style-as="h3">Titel H1 as H3</ks-a-heading>
-    <ks-a-heading tag="h2" style-as="h3">Titel H2 as H3</ks-a-heading>
-    <ks-a-heading tag="h3" style-as="h3">Titel H3 as H3</ks-a-heading>
+    <ks-a-heading><h1>Titel H1</h1></ks-a-heading>
+    <ks-a-heading><h2>Titel H2</h2></ks-a-heading>
+    <ks-a-heading><h3>Titel H3</h3></ks-a-heading>
+    <ks-a-heading style-as="h3"><h1>Titel H1 as H3</h1></ks-a-heading>
+    <ks-a-heading style-as="h3"><h2>Titel H2 as H3</h2></ks-a-heading>
+    <ks-a-heading style-as="h3"><h3>Titel H3 as H3</ks-a-heading>
     <!-- /Beispiele CMS Titel Komponenten -->
 
     <!-- CMS Content Container -->

--- a/src/es/components/pages/ContentPageWithoutSubNav.html
+++ b/src/es/components/pages/ContentPageWithoutSubNav.html
@@ -8,7 +8,7 @@
     width="100%"
 >
     <div>
-        <ks-a-heading tag="h1" color="white" content-stage>ContentPage (B&uuml;hne) Lorem Ipsum dolor bis zur zweiten Zeile</ks-a-heading>
+        <ks-a-heading color="white" content-stage><h1>ContentPage (B&uuml;hne) Lorem Ipsum dolor bis zur zweiten Zeile</h1></ks-a-heading>
         <p class="intro">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
             labore. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
             dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore

--- a/src/es/components/pages/StandortDetailPage.html
+++ b/src/es/components/pages/StandortDetailPage.html
@@ -13,8 +13,10 @@
                 <a-icon-mdx icon-name="ArrowLeft" size="1em"></a-icon-mdx> <span>&Uuml;bersicht</span>
             </a>
         </p>
-        <ks-a-heading tag="h1" content-stage>
-            Klubschule Migros Baden
+        <ks-a-heading content-stage>
+            <h1>
+                Klubschule Migros Baden
+            </h1>
         </ks-a-heading>
         <p class="intro">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magn.</p>
     </div>
@@ -338,7 +340,7 @@
 <!-- /CMS Teaser Slider -->
 
 <!-- Exceptionally added some inline styles to erase unwanted spacings -->
-<div id="angebote" style="width: 100%; margin-bottom: 0;">
+<div id="angebote" class="no-margin full-width">
     <ks-o-offers-page endpoint="https://miducabulaliwebappdev-test.azurewebsites.net/api/CourseSearch/withfacet"
     initial-request='{"filter":[],"PortalId":29,"sprachid":"d","MandantId":111,"ppage":1,"psize":6}'
     endpoint-auto-complete="https://dev.klubschule.ch/Umbraco/Api/Autocomplete/search"

--- a/src/es/components/pages/StandortUebersicht.html
+++ b/src/es/components/pages/StandortUebersicht.html
@@ -149,7 +149,9 @@
 ></ks-a-google-maps>
 
 <ks-o-body-section variant="narrow" has-background background="var(--mdx-sys-color-accent-6-subtle1)" no-margin-y>
-    <ks-a-heading tag="h1" display-3>Alle Standorte</ks-a-heading>
+    <ks-a-heading display-3>
+      <h1>Alle Standorte</h1>
+    </ks-a-heading>
 
     <!-- location list renders all the locations grouped by letter -->
     <ks-o-location-list

--- a/src/es/components/pages/TeaserCarousel.html
+++ b/src/es/components/pages/TeaserCarousel.html
@@ -2,8 +2,10 @@
 <ks-o-body-section variant="default">
     <code><a href="https://www.figma.com/file/PZlfqoBJ4RnR4rjpj38xai/Design-System-Core-%7C%C2%A0Klubschule-Master?type=design&node-id=164-10656&mode=dev" target="_blank">figma</a></code>
     
-    <ks-a-heading tag="h2" border-top>
-        Carousel Two 3 column
+    <ks-a-heading border-top>
+        <h2>
+            Carousel Two 3 column
+        </h2>
     </ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>
@@ -83,8 +85,10 @@
 <ks-o-body-section variant="default">
     <code><a href="https://www.figma.com/file/PZlfqoBJ4RnR4rjpj38xai/Design-System-Core-%7C%C2%A0Klubschule-Master?type=design&node-id=164-10656&mode=dev" target="_blank">figma</a></code>
     
-    <ks-a-heading tag="h2" border-top>
-        Carousel Two 3 column with content teaser
+    <ks-a-heading border-top>
+        <h2>
+            Carousel Two 3 column with content teaser
+        </h2>
     </ks-a-heading>
     <m-carousel-two namespace=carousel-two-3-column- nav-flex-wrap separate nav-justify-content="end" nav-align-self="end" no-default-arrow-nav no-default-nav no-default-nav-linking>
         <section>


### PR DESCRIPTION
Makes it possible to use headline html elements directly inside ks-a-headings.