### PR TITLE
fix(tracking): preserve ks_tracking_context through checkout flow [MIDUWEB-2265]

### DIFF
--- a/src/es/components/controllers/gtmEvent/GtmEvent.js
+++ b/src/es/components/controllers/gtmEvent/GtmEvent.js
@@ -78,9 +78,13 @@ export default class GTMEvent extends Shadow() {
   sendEvent(event) {
     this.eventData = JSON.parse(this.getAttribute('event-data'))
 
-    // Set tracking context for select_item and add_to_cart events
-    if ((this.eventData.event === 'select_item' || this.eventData.event === 'add_to_cart') && this.hasAttribute('tracking-context')) {
-      GTMEvent.setTrackingContext(this.getAttribute('tracking-context'))
+    // Set tracking context: select_item always overwrites, add_to_cart only if not yet set by a list page
+    if (this.hasAttribute('tracking-context')) {
+      if (this.eventData.event === 'select_item') {
+        GTMEvent.setTrackingContext(this.getAttribute('tracking-context'))
+      } else if (this.eventData.event === 'add_to_cart' && GTMEvent.getTrackingContext() === 'default') {
+        GTMEvent.setTrackingContext(this.getAttribute('tracking-context'))
+      }
     }
 
     // Add tracking context to ecommerce items

--- a/src/es/components/molecules/aboTile/AboTile.js
+++ b/src/es/components/molecules/aboTile/AboTile.js
@@ -104,7 +104,7 @@ export default class AboTile extends Shadow() {
       >
       </ks-m-event-detail>
       <div>
-        <ks-m-buttons course-data='${JSON.stringify(aboDetail).replace(/'/g, '’')}' is-abo></ks-m-buttons>
+        <ks-m-buttons course-data='${JSON.stringify(aboDetail).replace(/'/g, '’')}' is-abo tracking-context="${this.getAttribute('tracking-context') || 'matching_subscriptions'}"></ks-m-buttons>
       <div>
     `
     return this.fetchModules([

--- a/src/es/components/molecules/buttons/Buttons.js
+++ b/src/es/components/molecules/buttons/Buttons.js
@@ -262,8 +262,10 @@ export default class Buttons extends Shadow() {
   }
 
   openDialogOverlay(button) {
-    // Set tracking context before add_to_cart
-    if (this.hasAttribute('tracking-context')) GTMEvent.setTrackingContext(this.getAttribute('tracking-context'))
+    // Set tracking context before add_to_cart, but only if not yet set by a list page
+    if (this.hasAttribute('tracking-context') && GTMEvent.getTrackingContext() === 'default') {
+      GTMEvent.setTrackingContext(this.getAttribute('tracking-context'))
+    }
     // GTM Tracking of Click Register now
     const addToCartItem = GTMEvent.addTrackingContextToItem({
       // @ts-ignore


### PR DESCRIPTION
- GtmEvent: select_item always sets context, add_to_cart only if default
- Buttons: openDialogOverlay only overwrites context if default
- Buttons: wrap buttons in ks-c-gtm-event when tracking-context present
- OffersPage: skip tracking-context on detail page event list to preserve original
- Event: set tracking context on click when attribute present (wishlist)
- AboTile: pass tracking-context with default matching_subscriptions
- RecentlyViewedList: set search_overlay context before navigation